### PR TITLE
For using with bootstrap

### DIFF
--- a/angular-ui-switch.css
+++ b/angular-ui-switch.css
@@ -3,6 +3,7 @@
   border: 1px solid #dfdfdf;
   position: relative;
   display: inline-block;
+  box-sizing: content-box;
   overflow: visible;
   width: 52px;
   height: 30px;


### PR DESCRIPTION
Because bootstrap using box-sizing: border-box; by default
