### PR TITLE
add 'main' key for interraction with wiredep

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,7 @@
 {
   "name": "angular-ui-switch",
   "version": "0.0.5",
+  "main": ["angular-ui-switch.js", "angular-ui-switch.css"],
   "authors": [
     "xpeper <xpepermint@gmail.com>"
   ],


### PR DESCRIPTION
Gives the entry point of this module for bower.

Giving the _angular-ui-switch.js_ allow wiredep do include automaticly the &lt;script&gt; tag in index.html
Same thing for _angular-ui-switch.css_ file.
