### PR TITLE
Doesn't work when <switch> is inside <label>

### DIFF
--- a/angular-ui-switch.js
+++ b/angular-ui-switch.js
@@ -9,7 +9,8 @@ angular.module('uiSwitch', [])
       var html = '';
       html += '<span';
       html +=   ' class="switch' + (attrs.class ? ' ' + attrs.class : '') + '"';
-      html +=   attrs.ngModel ? ' ng-click="' + attrs.disabled + ' ? ' + attrs.ngModel + ' : ' + attrs.ngModel + '=!' + attrs.ngModel + (attrs.ngChange ? '; ' + attrs.ngChange + '()"' : '"') : '';
+      html += (attrs.ngModel && !element.closest('label').length) ? ' ng-click="' + attrs.disabled + ' ? ' +
+        attrs.ngModel + ' : ' + attrs.ngModel + '=!' + attrs.ngModel + (attrs.ngChange ? '; ' + attrs.ngChange + '()"' : '"') : '';
       html +=   ' ng-class="{ checked:' + attrs.ngModel + ', disabled:' + attrs.disabled + ' }"';
       html +=   '>';
       html +=   '<small></small>';


### PR DESCRIPTION
This fixes the state when switch is inside of the `<label>` element.
