### PR TITLE
Fix missing "style" directive within package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.1",
   "description": "iOS 7 style switch directive for AngularJS",
   "main": "angular-ui-switch.js",
+  "style": "angular-ui-switch.css",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
The `style` directive within package.json is required when pulling in the module so the correct CSS can be loaded.

The work around at the moment is to load the CSS separately. The attached fixes this in the main manifest.
